### PR TITLE
Using v70.0.1 release for Windows build

### DIFF
--- a/swigged.llvm.native/build.ps1
+++ b/swigged.llvm.native/build.ps1
@@ -29,7 +29,7 @@ echo "Downloading LLVM binaries from github.com/kaby76/llvm/..."
   [Net.SecurityProtocolType]::Tls12 -bor `
   [Net.SecurityProtocolType]::Tls11 -bor `
   [Net.SecurityProtocolType]::Tls
-curl -O x64-Release.tar.gz https://github.com/kaby76/llvm/releases/download/v6.0.4/x64-Release.tar.gz
+curl -O x64-Release.tar.gz https://github.com/kaby76/llvm/releases/download/v70.0.1/x64-Release.tar.gz
 echo "Unpacking binaries..."
 bash -lc "pwd"
 bash -lc "gzip -d x64-Release.tar.gz"


### PR DESCRIPTION
Impossible to build windows target because of missing LLVMGetSourceFileName in llvm 6.0